### PR TITLE
Update basic.rb

### DIFF
--- a/extensions/basic/lib/basic.rb
+++ b/extensions/basic/lib/basic.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'java' # we must use jruby runtime
+require 'jruby' # we must use jruby runtime
 
 # load the jar from the local directory
 require_relative 'jruby-ext.jar' 


### PR DESCRIPTION
Since JRuby-9.2.11.xx need to explicitly import `jruby`, import `java`doesn't work anymore (correct me if I'm wrong)